### PR TITLE
Fix MultiNest MPI fallback when mpi4py is missing

### DIFF
--- a/__multinest.py
+++ b/__multinest.py
@@ -13,6 +13,8 @@ try:
     MPIimport = True
 except ImportError:
     MPIimport = False
+    MPIrank = 0
+    MPIsize = 1
 
 if MPIimport:
     if MPIrank == 1:


### PR DESCRIPTION
Sets MPIrank=0 and MPIsize=1 when mpi4py is unavailable to prevent NameError during MultiNest initialization.